### PR TITLE
Add mockito_vendor package and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/setup-ros@0.0.25
+      with:
+        required-ros-distributions: foxy
+    - uses: ros-tooling/action-ros-ci@0.0.19
+      with:
+        package-name: mockito_vendor
+        target-ros2-distro: foxy
+        vcs-repo-file-url: ${{ github.workspace }}/.github/workflows/depends.repos

--- a/.github/workflows/depends.repos
+++ b/.github/workflows/depends.repos
@@ -4,3 +4,8 @@ repositories:
     type: git
     url: https://github.com/ros2-java/ros2_java.git
     version: dashing
+  # Dependency of ament_cmake_export_jars
+  ament_java:
+    type: git
+    url: https://github.com/ros2-java/ament_java.git
+    version: master

--- a/.github/workflows/depends.repos
+++ b/.github/workflows/depends.repos
@@ -1,0 +1,6 @@
+repositories:
+  # Contains ament_cmake_export_jars package
+  ros2_java:
+    type: git
+    url: https://github.com/ros2-java/ros2_java.git
+    version: dashing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.5)
+project(mockito_vendor)
+
+find_package(ament_cmake_export_jars REQUIRED)
+
+include(UseJava)
+
+# Find jars for Mockito and it's dependencies
+set(jars_to_find
+  "mockito-core"
+  "byte-buddy"
+  "byte-buddy-agent"
+  "objenesis"
+)
+
+# Download 2.23.0 (version provided by Ubuntu Focal)
+set(mockito-core_version "2.23.0")
+set(mockito-core_sha256 "637991bfc37fdd2a7adfe610f2ee5290acf9b15a7e4347bc3c96c61ed9dfe043")
+set(mockito-core_url "https://search.maven.org/remotecontent?filepath=org/mockito/mockito-core/${mockito-core_version}/mockito-core-${mockito-core_version}.jar")
+
+# Dependencies of Mockito 2.23.0
+set(byte-buddy_version "1.9.0")
+set(byte-buddy_sha256 "695d00c430d7111196c5be8de2ad7d289abfba91636fa4003bd8950d501b8740")
+set(byte-buddy_url "https://search.maven.org/remotecontent?filepath=net/bytebuddy/byte-buddy/${byte-buddy_version}/byte-buddy-${byte-buddy_version}.jar")
+
+set(byte-buddy-agent_version "1.9.0")
+set(byte-buddy-agent_sha256 "f1b5865730f0ae36539d91984d2dbf38ce7640c3db4c70b1a778395e579b3229")
+set(byte-buddy-agent_url "https://search.maven.org/remotecontent?filepath=net/bytebuddy/byte-buddy-agent/${byte-buddy-agent_version}/byte-buddy-agent-${byte-buddy-agent_version}.jar")
+
+set(objenesis_version "2.6")
+set(objenesis_sha256 "5e168368fbc250af3c79aa5fef0c3467a2d64e5a7bd74005f25d8399aeb0708d")
+set(objenesis_url "https://search.maven.org/remotecontent?filepath=org/objenesis/objenesis/${objenesis_version}/objenesis-${objenesis_version}.jar")
+
+set(${PROJECT_NAME}_exported_jars "")
+foreach(jar_name IN LISTS jars_to_find)
+  message(STATUS "Finding JAR '${jar_name}'")
+  find_jar(${jar_name}_path NAME "${jar_name}")
+  if(NOT ${jar_name}_path)
+    message(STATUS "JAR not found '${jar_name}', downloading from '${${jar_name}_url}")
+    set(${jar_name}_download_path "${CMAKE_CURRENT_BINARY_DIR}/jars/${jar_name}-${${jar_name}_version}.jar")
+    file(DOWNLOAD ${${jar_name}_url} ${${jar_name}_download_path} EXPECTED_HASH SHA256=${${jar_name}_sha256})
+    install(FILES ${${jar_name}_download_path}
+      DESTINATION "share/${PROJECT_NAME}/java"
+    )
+    set(${jar_name}_path "share/${PROJECT_NAME}/java/${jar_name}-${${jar_name}_version}.jar")
+  endif()
+  list(APPEND ${PROJECT_NAME}_exported_jars "${${jar_name}_path}")
+endforeach()
+
+ament_export_jars(${${PROJECT_NAME}_exported_jars})
+
+ament_package()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # mockito_vendor
+
+Vendor package for the tasty [Mockito mocking framework](https://site.mockito.org/).
+
+## License
+
+Both this package and Mockito are licensed under the MIT License.

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>mockito_vendor</name>
+  <version>0.0.0</version>
+  <description>Provides the Mockito mocking framework.</description>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+
+  <!-- Both this package and Mockito are MIT -->
+  <license>MIT</license>
+  <url type="website">https://site.mockito.org</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_jars</buildtool_depend>
+
+  <build_depend>ament_cmake_export_jars</build_depend>
+
+  <depend>libmockito-java</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
This supports using [Mockito](https://site.mockito.org/) on platforms that do not have have a system installed version.

For context, I'd like to start using Mockito for ROS 2 Java unit tests (e.g. https://github.com/osrf/ros2_java/pull/22)